### PR TITLE
Added "error: array type 'char [50]' is not assignable" to types of errors recognizes.

### DIFF
--- a/helpers/make.py
+++ b/helpers/make.py
@@ -113,3 +113,23 @@ def up_to_date(lines):
     ]
 
     return lines[0:1], response
+
+@helper("make")
+def strcpy(lines):
+    """
+    cc     strcpy.c   -o strcpy
+    strcpy.c:6:11: error: array type 'char [50]' is not assignable
+        hello = "hello, world!"
+        ~~~~~ ^
+    1 error generated.
+    make: *** [strcpy] Error 1
+    """
+    matches = re.search(r"error: array type 'char [[0-9]+]' is not assignable$", lines[1])
+    if not matches:
+        return
+    
+    response = [
+        "You can't assign to an array, only copy to it. Use strcpy() instead."
+    ]
+
+    return lines[1:4], response

--- a/test_files/clang/strcpy.c
+++ b/test_files/clang/strcpy.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void) {
+    char hello[50];
+
+    hello = "hello, world!"
+}


### PR DESCRIPTION
While using `help50` today, I noticed that the following error was not recognized by `help50`.

This is the error message I got:
```
cc     strcpy.c   -o strcpy
strcpy.c:6:11: error: array type 'char [50]' is not assignable
    hello = "hello, world!"
    ~~~~~ ^
1 error generated.
make: *** [strcpy] Error 1
```

And this is what happens when I run `help50`:
```
Asking for help...

strcpy.c:6:11: error: array type 'char [50]' is not assignable

Not quite sure how to help, but focus your attention on line 6 of strcpy.c!
```

`test_files/clang/strcpy.c` is an example of a C file that would raise the error above. I have added `def strcpy(lines)` to the `make.py` file. However, I had some difficulties testing my code. I have written the code to the best of my abilities and I believe that if this feature is implemented, it would benefit others.

If you have any questions, feel free to reach out to me on GitHub!